### PR TITLE
Use Ruby rocket syntax for Hash

### DIFF
--- a/lib/jekyll_frontmatter_tests.rb
+++ b/lib/jekyll_frontmatter_tests.rb
@@ -7,7 +7,7 @@ class FrontmatterTests < Jekyll::Command
     def config
       config = Jekyll.configuration
       if config.key('frontmatter_tests').nil?
-        config['frontmatter_tests'] = {'path': File.join("deploy", "tests", "schema")}
+        config['frontmatter_tests'] = {'path' => File.join("deploy", "tests", "schema")}
       end
       @config ||= config['frontmatter_tests']
     end


### PR DESCRIPTION
Was just trying to help debug a change in 18F/18f.gsa.gov and noticed a problem with 0.0.5. What you have now is a SyntaxError.

/cc @gboone 
