### PR TITLE
Contributing Links Update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Where Contributions Go
 
-Submit contributions to https://github.com/18F/jekyll-frontmatter-tests as a pull request to the `master` branch.
+Submit contributions to https://github.com/18F/jekyll_frontmatter_tests as a pull request to the `master` branch.
 
-File issues with bug reports or suggestions at https://github.com/18F/jekyll-frontmatter-tests/issues/new/
+File issues with bug reports or suggestions at https://github.com/18F/jekyll_frontmatter_tests/issues/new/
 
 ## Public domain
 


### PR DESCRIPTION
Pull request for minor fix to link references in the contributing.md file.  Noticed they were broken, not that most folks couldn't figure it out anyway, but thought this might be better as folks are checking out how to contribute.
