### PR TITLE
Adding ability to skip subdirectories

### DIFF
--- a/lib/jekyll_frontmatter_tests.rb
+++ b/lib/jekyll_frontmatter_tests.rb
@@ -33,17 +33,20 @@ class FrontmatterTests < Jekyll::Command
 
     # Public: processes a collection against a schema
     #
-    # schmea - the hash-representation of a schema file
+    # schema - the hash-representation of a schema file
     #
     # Opens each file in the collection's expected directory and checks the
     # file's frontmatter for the expected keys and the expected format of the
     # values.
+    #
+    # NOTE - As it iterates through files, subdirectories will be ignored
     #
     # Returns true or false depending on the success of the check.
     def process(schema)
     	dir = File.join(schema['config']['path'])
     	passfail = Array.new
     	Dir.open(dir).each do |f|
+        next if File.directory?(File.join(dir, f))
     		file = File.open(File.join(dir, f))
     		unless schema['config']['ignore'].include?(f)
     			data = YAML.load_file(file)

--- a/lib/jekyll_frontmatter_tests.rb
+++ b/lib/jekyll_frontmatter_tests.rb
@@ -46,7 +46,7 @@ class FrontmatterTests < Jekyll::Command
     	dir = File.join(schema['config']['path'])
     	passfail = Array.new
     	Dir.open(dir).each do |f|
-        next if File.directory?(File.join(dir, f))
+    		next if File.directory?(File.join(dir, f))
     		file = File.open(File.join(dir, f))
     		unless schema['config']['ignore'].include?(f)
     			data = YAML.load_file(file)


### PR DESCRIPTION
Great idea for this gem for testing yml validation, it is helping me a lot!

I was receiving errors when trying to run schema tests on directories that included subdirectories within them.

For example, I was configuring a schema test for a _posts directory `path: '_posts'`, however, some jekyll sites have subdirectories within _posts for organization and different types of posts.

I, personally, plan on running slightly different tests for the subdirectories, so I added a `next if` to skip subdirectories.  I'm not sure if this is desired or the best way to handle (maybe some folks would want to iterate through subdirectories?) but it helped on my end, so thought I'd share if helpful.  If you think it should be handled differently, I'm open to suggestions!
