### PR TITLE
Updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,218 @@
+# This configuration only includes the cops that differ from the Rubocop
+# defaults, which can be found here:
+# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+# https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
+# https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml
+
+AllCops:
+  Include:
+    - '**/Gemfile'
+    - '**/Rakefile'
+  Exclude:
+    - 'bin/**/*'
+    - 'db/schema.rb'
+  UseCache: true
+
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: true
+  Max: 15
+  Exclude:
+  - spec/**/*
+
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: true
+  CountComments: false
+  Max: 100
+  Exclude:
+  - spec/**/*
+
+Metrics/LineLength:
+  Description: Limit lines to 80 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
+  Enabled: true
+  Max: 100
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: true
+  CountComments: false
+  Max: 10
+  Exclude:
+  - 'db/migrate/*'
+  - spec/**/*
+
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 100
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: true
+  Exclude:
+  - spec/**/*
+
+Rails/TimeZone:
+  # The value `strict` means that `Time` should be used with `zone`.
+  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
+  Enabled: true
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Style/AlignParameters:
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/AndOr:
+  Description: Use &&/|| instead of and/or.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
+  EnforcedStyle: conditionals
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+
+# Warn on empty else statements
+# empty - warn only on empty else
+# nil - warn on else with nil in it
+# both - warn on empty else and else with nil in it
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    - empty
+    - nil
+    - both
+
+Style/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
+
+Style/FrozenStringLiteralComment:
+  StyleGuide: >-
+    Check for the comment `# frozen_string_literal: true` to the top
+    of files. This will help with upgrading to Ruby 3.0.
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: true
+  MaxLineLength: 100
+
+# Checks the indentation of the first element in an array literal.
+Style/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/SignalException:
+  Description: 'Checks for proper usage of fail and raise.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail'
+  EnforcedStyle: only_raise
+  SupportedStyles:
+    - only_raise
+    - only_fail
+    - semantic
+
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+  ConsistentQuotesInMultiline: true
+
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma

--- a/lib/jekyll_frontmatter_tests.rb
+++ b/lib/jekyll_frontmatter_tests.rb
@@ -12,7 +12,7 @@ class FrontmatterTests < Jekyll::Command
     # exists.
     def loadschema(file)
       schema = File.join(@schema['path'], file)
-    	if File.exists?(schema)
+      if File.exist?(schema)
         YAML.load_file(schema)
       else
         puts "No schema for #{file}"
@@ -32,24 +32,23 @@ class FrontmatterTests < Jekyll::Command
     #
     # Returns true or false depending on the success of the check.
     def process(schema)
-    	dir = File.join(schema['config']['path'])
-    	passfail = Array.new
-    	Dir.open(dir).each do |f|
-    		next if File.directory?(File.join(dir, f))
-    		file = File.open(File.join(dir, f))
-    		unless schema['config']['ignore'].include?(f)
-    			data = YAML.load_file(file)
-    			passfail.push check_keys(data, schema.keys, f)
-    			passfail.push check_types(data, schema)
-    		end
-    	end
+      dir = File.join(schema['config']['path'])
+      passfail = []
+      Dir.open(dir).each do |f|
+        next if File.directory?(File.join(dir, f))
+        file = File.open(File.join(dir, f))
+        next if schema['config']['ignore'].include?(f)
+        data = YAML.load_file(file)
+        passfail.push check_keys(data, schema.keys, f)
+        passfail.push check_types(data, schema)
+      end
       passfail.keep_if { |p| p == false }
-    	if passfail.empty?
-    		return true
-    	else
+      if passfail.empty?
+        return true
+      else
         puts "There were #{passfail.count} errors".red
-    		return false
-    	end
+        return false
+      end
     end
 
     # Public: checks a hash for expected keys
@@ -59,21 +58,21 @@ class FrontmatterTests < Jekyll::Command
     #        a schema file by loadschema()
     # title - A string representing `data`'s name
     def check_keys(target, keys, title)
-    	keys = keys - ['config']
-    	unless target.respond_to?('keys')
-    		puts "The file #{title} is missing all frontmatter.".red
-    		return false
-    	end
-    	diff = keys - target.keys
+      keys -= ['config']
+      unless target.respond_to?('keys')
+        puts "The file #{title} is missing all frontmatter.".red
+        return false
+      end
+      diff = keys - target.keys
       if diff.empty?
-    		return true
-    	else
-    		puts "\nThe file #{title} is missing the following keys:".red
-    		for k in diff
-    			puts "    * #{k}".red
-    		end
-    		return false
-    	end
+        return true
+      else
+        puts "\nThe file #{title} is missing the following keys:".red
+        for k in diff
+          puts "    * #{k}".red
+        end
+        return false
+      end
     end
 
     # Public: tests all documents that are "posts"
@@ -82,7 +81,7 @@ class FrontmatterTests < Jekyll::Command
     # it.
     def test_posts
       puts 'testing posts'.green
-      yepnope = Array.new.push process(loadschema('_posts.yml'))
+      yepnope = [].push process(loadschema('_posts.yml'))
       puts 'Finished testing'.green
       yepnope
     end
@@ -94,7 +93,7 @@ class FrontmatterTests < Jekyll::Command
     # `collections` is split into an array and each document is loaded and
     # processed against its respective schema.
     def test_collections(collections)
-      yepnope = Array.new
+      yepnope = []
       for c in collections
         puts "Testing #{c}".green
         yepnope.push process(loadschema("_#{c}.yml"))
@@ -107,14 +106,13 @@ class FrontmatterTests < Jekyll::Command
     # `deploy/tests/scema`
     def test_everything
       schema = Dir.open(@schema['path'])
-      yepnope = Array.new
-      schema.each { |s|
-        if s.start_with?('_')
-          puts "Testing #{s}".green
-          yepnope.push process(loadschema(s))
-          puts "Finished testing #{s}".green
-        end
-      }
+      yepnope = []
+      schema.each do |s|
+        next unless s.start_with?('_')
+        puts "Testing #{s}".green
+        yepnope.push process(loadschema(s))
+        puts "Finished testing #{s}".green
+      end
       yepnope
     end
 
@@ -131,8 +129,7 @@ class FrontmatterTests < Jekyll::Command
     #          compare all docs in _posts with the provided schema.
     #
     # The test runner pushes the result of each test into a `results` array and # exits `1` if any tests fail or `0` if all is well.
-    def test_frontmatter(args, options)
-
+    def test_frontmatter(_args, options)
       puts 'starting tests'
       if options['posts']
         results = test_posts
@@ -142,12 +139,12 @@ class FrontmatterTests < Jekyll::Command
       else
         results = test_everything
       end
-      unless results.find_index{ |r| r == false }
+      if results.find_index { |r| r == false }
+        puts 'The test exited with errors, see above.'
+        exit 1
+      else
         puts 'Tests finished!'
         exit 0
-      else
-        puts "The test exited with errors, see above."
-        exit 1
       end
     end
 
@@ -158,11 +155,11 @@ class FrontmatterTests < Jekyll::Command
     def init_with_program(prog)
       config = Jekyll.configuration
       unless config.key?('frontmatter_tests')
-        config['frontmatter_tests'] = {'path' => File.join("deploy", "tests", "schema")}
+        config['frontmatter_tests'] = { 'path' => File.join('deploy', 'tests', 'schema') }
       end
       @schema ||= config['frontmatter_tests']
       prog.command(:test) do |c|
-        c.syntax "test [options]"
+        c.syntax 'test [options]'
         c.description 'Test your site for frontmatter.'
 
         c.option 'posts', '-p', 'Target only posts'
@@ -170,41 +167,38 @@ class FrontmatterTests < Jekyll::Command
         c.option 'all', '-a', 'Test all collections (Default)'
 
         c.action do |args, options|
-          if options.empty?
-            options = {"all" => true}
-          end
+          options = { 'all' => true } if options.empty?
           test_frontmatter(args, options)
         end
       end
     end
+
     # Internal: eventually, validate that the *values* match expected types
     #
     # For example, if we expect the `date` key to be in yyyy-mm-dd format, validate
     # that it's been entered in that format. If we expect authors to be an array,
     # make sure we're getting an array.
     def check_types(data, schema)
-    	unless data.respond_to?('keys')
-    		return false
-    	end
-    	for s in schema
-    		key  = s[0]
-    		if s[1].class == Hash
-    			type = s[1]['type']
-    		else
-    			type = s[1]
-    		end
+      return false unless data.respond_to?('keys')
+      for s in schema
+        key = s[0]
+        type = if s[1].class == Hash
+                 s[1]['type']
+               else
+                 s[1]
+               end
 
-    		if type == "Array" and data[key].class == Array
-    			return true
-    		elsif type == "String" and data[key].class == String
-    			return true
-    		elsif type == "Date"
-    			return true
-    		else
-    			puts "    * Data is of the wrong type for key #{key}, expected #{type} but was #{data[key].class}\n\n"
-    			return false
-    		end
-    	end
+        if type == 'Array' && data[key].class == Array
+          return true
+        elsif type == 'String' && data[key].class == String
+          return true
+        elsif type == 'Date'
+          return true
+        else
+          puts "    * Data is of the wrong type for key #{key}, expected #{type} but was #{data[key].class}\n\n"
+          return false
+        end
+      end
     end
   end
 end

--- a/lib/jekyll_frontmatter_tests.rb
+++ b/lib/jekyll_frontmatter_tests.rb
@@ -43,7 +43,7 @@ class FrontmatterTests < Jekyll::Command
         data = YAML.load_file(file)
 
         passfail.push check_keys(data, schema.keys, f)
-        passfail.push check_types(data, schema, File.join(dir,f))
+        passfail.push check_types(data, schema, File.join(dir, f))
       end
       passfail.keep_if { |p| p == false }
       if passfail.empty?
@@ -191,41 +191,39 @@ class FrontmatterTests < Jekyll::Command
                else
                  value
                end
-        'testing'
-        if is_required?(key, schema)
-          if key == 'config'
-            next
-          elsif value.class == Hash
-            if value.keys.include? 'one_of'
-              if !is_one_of?(data[key], value['one_of'])
-                puts "    * '#{data[key]}' was not in the list of expected values in #{file}.".red
-                puts "      expected one of the following: #{s[1]['one_of']}\n".red
-                return false
-              else
-                next
-              end
+        next unless required?(key, schema)
+        if key == 'config'
+          next
+        elsif value.class == Hash
+          if value.keys.include? 'one_of'
+            if !one_of?(data[key], value['one_of'])
+              puts "    * '#{data[key]}' was not in the list of expected values in #{file}.".red
+              puts "      expected one of the following: #{s[1]['one_of']}\n".red
+              return false
             else
               next
             end
-          elsif type == 'Array' && data[key].class == Array
-            next
-          elsif type == 'Boolean' && data[key].is_a?(Boolean)
-            next
-          elsif type == 'String' && data[key].class == String
-            next
-          elsif type == 'Date'
-            next
           else
-            puts "    * '#{key}' is not a valid key in #{file}. Expected #{type} but was #{data[key].class}\n\n"
-            return false
+            next
           end
+        elsif type == 'Array' && data[key].class == Array
+          next
+        elsif type == 'Boolean' && data[key].is_a?(Boolean)
+          next
+        elsif type == 'String' && data[key].class == String
+          next
+        elsif type == 'Date'
+          next
+        else
+          puts "    * '#{key}' is not a valid key in #{file}. Expected #{type} but was #{data[key].class}\n\n"
+          return false
         end
       end
     end
 
     private
 
-    def is_one_of?(data, schema)
+    def one_of?(data, schema)
       if schema.instance_of?(Array) && data.instance_of?(Array)
       elsif schema.include? '.yml'
         schema_list = YAML.load_file(File.join(Dir.pwd, 'tests', 'schema', schema))
@@ -235,14 +233,13 @@ class FrontmatterTests < Jekyll::Command
       end
     end
 
-    def is_required?(key, schema)
+    def required?(key, schema)
       if schema['config']
         !schema['config']['optional'].include? key
       else
         true
       end
     end
-
   end
 end
 


### PR DESCRIPTION
This PR addresses a few of the major concerns with the frontmatter tests. Specifically, it

- adds rubocop and updates the most egregious syntax errors
- adds support for `one_of` key checker. `one_of` either accepts
  - an Array of acceptable keys
  - a String filename with a `.yml` file extension. The yaml will be parsed and and transformed into an array of acceptable keys
- no longer stops checking a file's frontmatter after finding a single error

See in action: https://github.com/18F/18f.gsa.gov/pull/2187

cc @gboone 